### PR TITLE
Change ident for EVFILT_USER to 0 to avoid fd collision

### DIFF
--- a/kqueue.c
+++ b/kqueue.c
@@ -512,11 +512,11 @@ kq_sig_del(struct event_base *base, int nsignal, short old, short events, void *
 }
 
 
-/* OSX 10.6 and FreeBSD 8.1 add support for EVFILT_USER, which we can use
- * to wake up the event loop from another thread. */
+/* OSX 10.6, FreeBSD 8.1 and NetBSD 10.0 added support for EVFILT_USER,
+ * which we can use to wake up the event loop from another thread. */
 
 /* Magic number we use for our filter ID. */
-#define NOTIFY_IDENT 42
+#define NOTIFY_IDENT 0
 
 int
 event_kq_add_notify_event_(struct event_base *base)


### PR DESCRIPTION
Conventionally, ident for `EVFILT_USER` is set to 0 to avoid
collision of file descriptors, which is what other renowned
networking frameworks like netty(java), mio(rust), gnet(go),
swift-nio(swift), etc. do currently.